### PR TITLE
Support Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,11 @@ jobs:
     - run: yarn install
 
   tests:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, windows-latest]
     name: "Tests"
-    runs-on: ubuntu-latest
+    runs-on: "${{ matrix.platform }}"
     needs: [install_dependencies]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
   tooling:
     name: Tooling
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main'
+    if: github.repository == 'NullVoxPopuli/ember-apply' && github.ref != 'refs/heads/main'
     timeout-minutes: 2
     needs: [install_dependencies]
 
@@ -77,7 +77,7 @@ jobs:
   publish:
     name: Release
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.repository == 'NullVoxPopuli/ember-apply' && github.ref == 'refs/heads/main'
     needs: [tests]
 
     steps:

--- a/ember-apply/src/-private/project/utils.js
+++ b/ember-apply/src/-private/project/utils.js
@@ -69,13 +69,14 @@ export async function gitIgnore(pattern, heading) {
 /**
  * Uses git to return the path to the root of the project.
  * This is the absolute path to the root of the project / repository.
+ * Note: git for windows returns POSIX-style paths
  */
 export async function gitRoot() {
   let { stdout } = await execa('git', ['rev-parse', '--show-toplevel'], {
     cwd: process.cwd(),
   });
 
-  return stdout.trim();
+  return path.resolve(stdout.trim());
 }
 
 /**

--- a/ember-apply/src/cli/resolve.js
+++ b/ember-apply/src/cli/resolve.js
@@ -219,20 +219,18 @@ async function resolvePath(options) {
     return PATH_CACHE.get(name);
   }
 
-  let cwd = process.cwd();
-
   assert(name, 'name is required');
 
   let potentialLocations = [
     // local, but specified index.js
-    path.join(cwd, name),
+    path.resolve(name),
     // local, but without index.js
-    path.join(cwd, name, 'index.js'),
-    // local, but absolute path
-    path.join(name),
-    // local, but absolute path without specifying index.js
-    path.join(name, 'index.js'),
-  ];
+    path.resolve(name, 'index.js'),
+  ].map(p => {
+    // On Windows, the ESM loader requires that absolute paths must be valid file:// URLs.
+    // Absolute paths (e.g. with drive letters like "C:") can lead to ERR_UNSUPPORTED_ESM_URL_SCHEME
+    return p.match(/^[a-zA-Z]:/) ? `file://${p}` : p;
+  });
 
   let resolvedModule;
   let resolvedPath;

--- a/ember-apply/src/cli/resolve.js
+++ b/ember-apply/src/cli/resolve.js
@@ -226,7 +226,7 @@ async function resolvePath(options) {
     path.resolve(name),
     // local, but without index.js
     path.resolve(name, 'index.js'),
-  ].map(p => {
+  ].map((p) => {
     // On Windows, the ESM loader requires that absolute paths must be valid file:// URLs.
     // Absolute paths (e.g. with drive letters like "C:") can lead to ERR_UNSUPPORTED_ESM_URL_SCHEME
     return p.match(/^[a-zA-Z]:/) ? `file://${p}` : p;

--- a/ember-apply/tests/project.test.ts
+++ b/ember-apply/tests/project.test.ts
@@ -116,12 +116,12 @@ describe('project', () => {
       }
 
       expect(workspaces).toEqual([
-        root,
-        root + '/packages/a',
-        root + '/packages/b',
-        root + '/packages/c',
-        root + '/d',
-      ]);
+        '',
+        '/packages/a',
+        '/packages/b',
+        '/packages/c',
+        '/d',
+      ].map(p => path.resolve(root + p)));
     });
   });
 
@@ -130,13 +130,15 @@ describe('project', () => {
       let workspaces = await project.getWorkspaces();
       let root = await project.workspaceRoot();
 
-      expect(workspaces).toEqual([
-        root,
-        root + '/ember-apply',
-        root + '/packages/docs',
-        root + '/packages/ember/embroider',
-        root + '/packages/ember/tailwind',
-      ]);
+      expect(workspaces).toEqual(
+        [
+          '',
+          '/ember-apply',
+          '/packages/docs',
+          '/packages/ember/embroider',
+          '/packages/ember/tailwind',
+        ].map((p) => path.resolve(root + p))
+      );
     });
   });
 });

--- a/ember-apply/tests/project.test.ts
+++ b/ember-apply/tests/project.test.ts
@@ -115,13 +115,9 @@ describe('project', () => {
         workspaces.push(current);
       }
 
-      expect(workspaces).toEqual([
-        '',
-        '/packages/a',
-        '/packages/b',
-        '/packages/c',
-        '/d',
-      ].map(p => path.resolve(root + p)));
+      expect(workspaces).toEqual(
+        ['', '/packages/a', '/packages/b', '/packages/c', '/d'].map((p) => path.resolve(root + p))
+      );
     });
   });
 

--- a/ember-apply/vitest.config.ts
+++ b/ember-apply/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   test: {
-    testTimeout: 10_000,
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
   },
 });

--- a/packages/ember/embroider/vitest.config.ts
+++ b/packages/ember/embroider/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   test: {
-    testTimeout: 10_000,
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
   },
 });

--- a/packages/ember/tailwind/vitest.config.ts
+++ b/packages/ember/tailwind/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   test: {
-    testTimeout: 10_000,
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
   },
 });


### PR DESCRIPTION
This PR adds `windows-latest` to the CI test matrix and attempts to make the existing tests pass on that platform as well. This required modifying some functions that handled Windows paths as well as increasing the test timeout values (it might be possible to improve the Windows CI environment for better node.js / file system performance, but for now increasing the allowed test time seemed a reasonable solution).