### PR TITLE
Add cwd support to yarn

### DIFF
--- a/ember-apply/src/-private/project/utils.js
+++ b/ember-apply/src/-private/project/utils.js
@@ -154,7 +154,7 @@ export async function getWorkspaces(cwd = process.cwd()) {
 
   switch (packageManager) {
     case 'yarn': {
-      const list = await listYarnWorkspaces();
+      const list = await listYarnWorkspaces({ cwd });
 
       return list.map((workspace) => path.join(root, workspace.location));
     }


### PR DESCRIPTION
It was missing from yarn triggering the following error:

```
Error: Command failed: yarn workspaces list --verbose --json

    at ChildProcess.exithandler (node:child_process:402:12)
    at ChildProcess.emit (node:events:513:28)
    at maybeClose (node:internal/child_process:1100:16)
    at Socket.<anonymous> (node:internal/child_process:458:11)
    at Socket.emit (node:events:513:28)
    at Pipe.<anonymous> (node:net:301:12) {
  code: 1,
  killed: false,
  signal: null,
  cmd: 'yarn workspaces list --verbose --json',
  stdout: "\x1B[31m\x1B[1mUsage Error\x1B[22m\x1B[39m: The nearest package directory (/Users/justin/repos/changeset-recover) doesn't seem to be part of the project declared in /Users/justin.\n" +
    '\n' +
    "- If /Users/justin isn't intended to be a project, remove any yarn.lock and/or package.json file there.\n" +
    '- If /Users/justin is intended to be a project, it might be that you forgot to list repos/changeset-recover in its workspace configuration.\n' +
    '- Finally, if /Users/justin is fine and you intend repos/changeset-recover to be treated as a completely separate project (not even a workspace), create an empty yarn.lock file in it.\n' +
    '\n' +
    '\x1B[1m$ \x1B[22myarn workspaces list [--since] [-R,--recursive] [-v,--verbose] [--json]\n',
  stderr: ''
}
 ELIFECYCLE  Command failed with exit code 1.
```