### PR TITLE
Consistent test runs

### DIFF
--- a/ember-apply/src/test-utils.js
+++ b/ember-apply/src/test-utils.js
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'url';
 import { packageJson, project } from './index.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const EMBER_CLI_VERSION = '5.3'; // We can't install ember-cli as a devDependency since it then assumes we're an ember project and refuses to run generators.
 
 export async function newTmpDir() {
   const tmpDir = await fs.mkdtemp(
@@ -19,10 +20,13 @@ export async function newTmpDir() {
 export async function newEmberApp() {
   let dir = await newTmpDir();
 
-  await execa('ember', ['-v'], { cwd: dir });
-  await execa('ember', ['new', 'test-app', '--skip-npm'], {
-    cwd: dir,
-  });
+  await execa(
+    'pnpm',
+    ['dlx', `ember-cli@${EMBER_CLI_VERSION}`, 'new', 'test-app', '--skip-npm'],
+    {
+      cwd: dir,
+    },
+  );
 
   return path.join(dir, 'test-app');
 }
@@ -30,10 +34,19 @@ export async function newEmberApp() {
 export async function newEmberAddon() {
   let dir = await newTmpDir();
 
-  await execa('ember', ['-v'], { cwd: dir });
-  await execa('ember', ['addon', 'test-addon', '--skip-npm'], {
-    cwd: dir,
-  });
+  await execa(
+    'pnpm',
+    [
+      'dlx',
+      `ember-cli@${EMBER_CLI_VERSION}`,
+      'addon',
+      'test-addon',
+      '--skip-npm',
+    ],
+    {
+      cwd: dir,
+    },
+  );
 
   return path.join(dir, 'test-addon');
 }

--- a/packages/ember/embroider/vitest.config.ts
+++ b/packages/ember/embroider/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   test: {
-    testTimeout: 30_000,
+    testTimeout: 60_000,
     hookTimeout: 30_000,
   },
 });

--- a/packages/ember/tailwind-webpack/vitest.config.ts
+++ b/packages/ember/tailwind-webpack/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   test: {
-    testTimeout: 30_000,
+    testTimeout: 60_000,
     hookTimeout: 30_000,
   },
 });

--- a/packages/ember/tailwind/vitest.config.ts
+++ b/packages/ember/tailwind/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   test: {
-    testTimeout: 30_000,
+    testTimeout: 60_000,
     hookTimeout: 30_000,
   },
 });

--- a/packages/ember/unstable-embroider/vitest.config.ts
+++ b/packages/ember/unstable-embroider/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   test: {
-    testTimeout: 30_000,
+    testTimeout: 60_000,
     hookTimeout: 30_000,
   },
 });


### PR DESCRIPTION
This uses `pnpm dlx` to run a specific version of ember-cli. That should make the tests consistent without requiring ember-cli to be installed globally. We can't use a devDependency here since ember-cli then thinks this is an Ember project and refuses to run the app generator.

Closes #450 