### PR TITLE
fix: Incorrect paths

### DIFF
--- a/.changeset/long-beans-bathe.md
+++ b/.changeset/long-beans-bathe.md
@@ -1,0 +1,5 @@
+---
+"@ember-apply/tailwind-webpack": patch
+---
+
+Move tailwind config files in to <project>/config instead of <project>/app/config

--- a/packages/ember/tailwind-webpack/files/config/postcss.config.js
+++ b/packages/ember/tailwind-webpack/files/config/postcss.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   plugins: {
     tailwindcss: {
-      config: 'app/config/tailwind.config.js',
+      config: 'config/tailwind.config.js',
     },
     autoprefixer: {},
   },

--- a/packages/ember/tailwind-webpack/files/config/tailwind.config.js
+++ b/packages/ember/tailwind-webpack/files/config/tailwind.config.js
@@ -1,6 +1,6 @@
 const path = require('path');
 
-const appRoot = path.join(__dirname, '../../');
+const appRoot = path.join(__dirname, '../');
 const libraries = [
   /* someLibraryName */
 ];

--- a/packages/ember/tailwind-webpack/index.js
+++ b/packages/ember/tailwind-webpack/index.js
@@ -32,7 +32,7 @@ export default async function run() {
                   loader: 'postcss-loader',
                   options: {
                     postcssOptions: {
-                      config: 'app/config/postcss.config.js',
+                      config: 'config/postcss.config.js',
                     },
                   },
                 },

--- a/packages/ember/tailwind-webpack/vitest.config.ts
+++ b/packages/ember/tailwind-webpack/vitest.config.ts
@@ -1,0 +1,9 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  test: {
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+  },
+});


### PR DESCRIPTION
- In the previous PR for [tailwind-webpack](https://github.com/NullVoxPopuli/ember-apply/pull/493/files) I incorrectly assumed that config files are in `app/config`, they are only in `config`.
- From many project setups it seems like `config` folder is the correct one.
- Adjusting the scripts so that it can work and be in expected location.