### PR TITLE
tailwind webpack fix

### DIFF
--- a/.changeset/proud-boats-smile.md
+++ b/.changeset/proud-boats-smile.md
@@ -1,0 +1,12 @@
+---
+"@ember-apply/tailwind-webpack": patch
+---
+
+Fixes: #495
+
+- Make some check/throw so that the logic doesn ot just silently fail, but gives reasonable guidance.
+- Make sure that the import statement is inserted correctly.
+- We now assume the need to have embroider ready project.
+- We throw information if that is not adhered to.
+- Changed from HTML parser (why did I do that?) to jscodeshift one.
+- We throw when there is already `packagerOptions` defined.

--- a/packages/ember/tailwind-webpack/files/config/postcss.config.js
+++ b/packages/ember/tailwind-webpack/files/config/postcss.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   plugins: {
     tailwindcss: {
-      config: 'app/config/tailwind.config.js',
+      config: 'config/tailwind.config.js',
     },
     autoprefixer: {},
   },

--- a/packages/ember/tailwind-webpack/files/config/tailwind.config.js
+++ b/packages/ember/tailwind-webpack/files/config/tailwind.config.js
@@ -1,6 +1,6 @@
 const path = require('path');
 
-const appRoot = path.join(__dirname, '../../');
+const appRoot = path.join(__dirname, '../');
 const libraries = [
   /* someLibraryName */
 ];

--- a/packages/ember/tailwind-webpack/index.js
+++ b/packages/ember/tailwind-webpack/index.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { files, html, js, packageJson } from 'ember-apply';
+import { files, js, packageJson } from 'ember-apply';
 // eslint-disable-next-line n/no-unpublished-import
 import { execa } from 'execa';
 // eslint-disable-next-line n/no-unpublished-import

--- a/packages/ember/tailwind-webpack/index.js
+++ b/packages/ember/tailwind-webpack/index.js
@@ -71,10 +71,12 @@ export default async function run() {
 
   await js.transform(appFile, ({ root, j }) => {
     root
-      .find(j.ImportSpecifier)
-      .filter(path => path.node.imported.name === 'config')
-      .insertAfter(j.template.expression`import './app.css'`)
-  });
+      .find(j.ImportDefaultSpecifier)
+      .filter(path => path.node.local?.name === 'config' )
+      .forEach((path) => {
+        path.parent.insertAfter(`import './app.css'`)
+      })
+    });
 
   await execa('git', ['add', '.', '-N']);
 }

--- a/packages/ember/tailwind-webpack/index.js
+++ b/packages/ember/tailwind-webpack/index.js
@@ -32,7 +32,7 @@ export default async function run() {
                   loader: 'postcss-loader',
                   options: {
                     postcssOptions: {
-                      config: 'app/config/postcss.config.js',
+                      config: 'config/postcss.config.js',
                     },
                   },
                 },

--- a/packages/ember/tailwind-webpack/vitest.config.ts
+++ b/packages/ember/tailwind-webpack/vitest.config.ts
@@ -1,0 +1,9 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  test: {
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+  },
+});


### PR DESCRIPTION
- I did quite a few rewrites as it turnes out that the original implementation was pretty brittle.
- Make some check/throw so that the logic doesn ot just silently fail, but gives reasonable guidance.
- Make sure that the import statement is inserted correctly.
- We now assume the need to have embroider ready project.
- We throw information if that is not adhered to.
- Changed from HTML parser (why did I do that?) to jscodeshift one.
- We throw when there is already `packagerOptions` defined.

Fixes: #495 