### PR TITLE
Fix some issues with the `typescript` automation for v1 addons

### DIFF
--- a/packages/ember/typescript/src/ensure-ts-transpilation.js
+++ b/packages/ember/typescript/src/ensure-ts-transpilation.js
@@ -1,10 +1,12 @@
 import chalk from 'chalk';
-import { js } from 'ember-apply';
+import { ember, js } from 'ember-apply';
 
 export async function enableTSInECBuild() {
   await js.transform('ember-cli-build.js', async ({ root, j }) => {
     let utils = buildUtils(root, j);
-    let emberAppName = utils.getRequireName('ember-cli/lib/broccoli/ember-app');
+    let emberAppName = (await ember.isAddon)
+      ? utils.getRequireName('ember-cli/lib/broccoli/ember-addon')
+      : utils.getRequireName('ember-cli/lib/broccoli/ember-app');
 
     if (!emberAppName) {
       return couldNot();
@@ -120,4 +122,104 @@ function buildUtils(root, j) {
   };
 }
 
-export async function enableTSInAddonIndex() {}
+export async function enableTSInAddonIndex() {
+  await js.transform('index.js', async ({ root, j }) => {
+    /** @type {import('ast-types').namedTypes.ObjectExpression | undefined} */
+    let config;
+
+    // Get the object assigned to module.exports
+    //
+    // module.exports = { ... }
+    root
+      .find(j.AssignmentExpression, {
+        left: { object: { name: 'module' }, property: { name: 'exports' } },
+      })
+      .forEach((path) => {
+        if (path.node.right.type === 'ObjectExpression') {
+          config = path.node.right;
+        }
+      });
+
+    if (!config) {
+      return couldNotUpdateIndex();
+    }
+
+    // Ensure an options object exists and that we have a reference to it.
+    /** @type {import('ast-types').namedTypes.ObjectExpression | undefined} */
+    let options;
+
+    j(config)
+      .find(j.Property, { key: { name: 'options' } })
+      .forEach((path) => {
+        if (path.node.value.type === 'ObjectExpression') {
+          options = path.node.value;
+        }
+      });
+
+    if (!options) {
+      let optionsProperty = j.property(
+        'init',
+        j.identifier('options'),
+        j.objectExpression([]),
+      );
+
+      config.properties.push(optionsProperty);
+
+      if (optionsProperty.value.type === 'ObjectExpression') {
+        options = optionsProperty.value;
+      }
+    }
+
+    // make `ember-cli-babel` exist as a config object
+    let ecb = /** @type {import('ast-types').namedTypes.ObjectExpression} */ (
+      options
+    ).properties.find((property) => {
+      if (property.type === 'Property') {
+        if (property.key.type === 'Literal') {
+          return property.key.value === 'ember-cli-babel';
+        }
+      }
+
+      return false;
+    });
+
+    let ts = j.property(
+      'init',
+      j.identifier('enableTypeScriptTransform'),
+      j.literal(true),
+    );
+
+    if (!ecb) {
+      ecb = j.property(
+        'init',
+        j.literal('ember-cli-babel'),
+        j.objectExpression([ts]),
+      );
+
+      /** @type {import('ast-types').namedTypes.ObjectExpression} */
+      (options).properties.unshift(ecb);
+
+      return;
+    }
+
+    if (ecb.type === 'Property') {
+      let theActualObject = ecb.value;
+
+      if (theActualObject.type === 'ObjectExpression') {
+        theActualObject.properties.unshift(ts);
+
+        return;
+      }
+    }
+
+    couldNotUpdateIndex();
+  });
+}
+
+function couldNotUpdateIndex() {
+  console.warn(
+    chalk.yellow(
+      `Could not determine where to enable TypeScript in index.js. Please refer to the docs: https://github.com/emberjs/ember-cli-babel#enabling-typescript-transpilation`,
+    ),
+  );
+}

--- a/packages/ember/typescript/src/eslint.js
+++ b/packages/ember/typescript/src/eslint.js
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import { npm, packageJson } from 'ember-apply';
 
 const standardDeps = [
@@ -11,4 +12,9 @@ export async function setupESLint() {
   await packageJson.addDevDependencies(depsWithVersions);
 
   // TODO: append an overrides entry
+  console.warn(
+    chalk.yellow(
+      `Updating the .eslintrc.js file to support TypeScript hasn't been automated yet.`,
+    ),
+  );
 }

--- a/packages/ember/typescript/src/package-json.js
+++ b/packages/ember/typescript/src/package-json.js
@@ -7,7 +7,7 @@ export async function adjustAppScripts() {
 import { canUseBuiltInTypes, isEmberDataPresent } from './queries.js';
 
 export async function adjustAddonScripts() {
-  throw new Error(`Addons are not yet supported. PR's welcome!`);
+  await adjustAppScripts();
 }
 
 const standardDeps = [

--- a/packages/ember/typescript/src/types-directory.js
+++ b/packages/ember/typescript/src/types-directory.js
@@ -56,6 +56,8 @@ export async function createAppTypesDirectory() {
 }
 
 export async function createAddonTypesDirectory() {
+  await fse.ensureDir('types');
+
   if (await canUseBuiltInTypes()) {
     await fse.writeFile(
       'types/global.d.ts',
@@ -66,6 +68,7 @@ export async function createAddonTypesDirectory() {
     );
   }
 
+  await fse.ensureDir('unpublished-development-types');
   await fse.writeFile(
     `unpublished-development-types/glint.d.ts`,
     stripIndent`


### PR DESCRIPTION
Not everything is fully automated, but it doesn't throw any errors anymore and the console messages should provide enough guidance to finish the work manually.

closes #527 