### PR TITLE
docs: Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Known working capabilities:
 ### `tailwind-webpack`
 
 ```shell
-npm ember-apply tailwind-webpack
+npx ember-apply tailwind-webpack
 ```
 
 _Automates the official [Tailwind + Ember.js guide](https://tailwindcss.com/docs/guides/emberjs)_


### PR DESCRIPTION
- It's `npx` when executing scripts, not `npm`