### PR TITLE
Fix unstable embroider applyable that sets the pnpm.overrides

### DIFF
--- a/packages/ember/unstable-embroider/index.js
+++ b/packages/ember/unstable-embroider/index.js
@@ -52,6 +52,8 @@ async function useUnstableEmbroider() {
   // Handle transient dependencies
   await packageJson.modify((json) => {
     for (let [name, version] of withVersions) {
+      json.pnpm ||= {};
+      json.pnpm.overrides ||= {};
       json.pnpm.overrides[name] = version;
     }
   });


### PR DESCRIPTION
Previously it errored when `pnpm.overrides` was missing