### PR TITLE
docs: Create new README section for external apply-ables

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ npx ember-apply ../../path/to/some/script.js # ESM required
 npx ember-apply ../../path/to/some/script.mjs
 ```
 
+## External apply-ables
+
+- [apply-gts](https://github.com/tcarterjr/apply-gts) - Automates the steps for adding gjs/gts & Glint to an existing Ember app.
 
 ## Adding a new applyable to this repository
 


### PR DESCRIPTION
- Fixes: #555
- Maybe it would be also worth to add sub-section under `Features` named `Internal apply-ables` to make sure there are two of those? So it's balanced information?