### PR TITLE
feat: Basic tailwind-vite applyable

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ _Automates the official [Tailwind + Ember.js guide](https://tailwindcss.com/docs
 - Instead of placing `postcss.config.js` and `tailwind.config.js` into the project root, it places them to `config/` directory.
 - Does not need any special command for building tailwind styles they will be built (and watched) together with `npm start`.
 
+### `tailwind-vite`
+
+```shell
+npx ember-apply tailwind-vite
+```
+
+_Automates the official [Tailwind + Vite guide](https://tailwindcss.com/docs/guides/vite) so that it's compatible with [embroider-build/app-blueprint](https://github.com/embroider-build/app-blueprint)_
+
 ### `embroider`
 
 ```shell

--- a/packages/ember/tailwind-vite/.eslintignore
+++ b/packages/ember/tailwind-vite/.eslintignore
@@ -1,0 +1,3 @@
+declarations/
+node_modules/
+files/

--- a/packages/ember/tailwind-vite/.eslintrc.cjs
+++ b/packages/ember/tailwind-vite/.eslintrc.cjs
@@ -1,0 +1,10 @@
+"use strict";
+
+const { configs } = require("@nullvoxpopuli/eslint-configs");
+
+const config = configs.node();
+
+module.exports = {
+  ...config,
+  overrides: [...config.overrides],
+};

--- a/packages/ember/tailwind-vite/__snapshots__/index.test.ts.snap
+++ b/packages/ember/tailwind-vite/__snapshots__/index.test.ts.snap
@@ -1,38 +1,12 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`tailwind-vite > applying to an ember app > works via CLI 1`] = `
-" app/app.ts               | 2 ++
- app/styles/app.css       | 3 +++
- package.json             | 3 +++
- postcss.config.js (new)  | 8 ++++++++
- tailwind.config.js (new) | 9 +++++++++
- 5 files changed, 25 insertions(+)"
+" package.json | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)"
 `;
 
 exports[`tailwind-vite > applying to an ember app > works via CLI 2`] = `
-"diff --git a/app/app.ts b/app/app.ts
-index 1ba9342..daff0cc 100644
---- a/app/app.ts
-+++ b/app/app.ts
-@@ -3,6 +3,8 @@ import Resolver from 'ember-resolver';
- import loadInitializers from 'ember-load-initializers';
- import config from 'test-app/config/environment';
- 
-+import './styles/app.css'
-+
- export default class App extends Application {
-   modulePrefix = config.modulePrefix;
-   podModulePrefix = config.podModulePrefix;
-diff --git a/app/styles/app.css b/app/styles/app.css
-index 2763afa..192268f 100644
---- a/app/styles/app.css
-+++ b/app/styles/app.css
-@@ -1 +1,4 @@
- /* Ember supports plain CSS out of the box. More info: https://cli.emberjs.com/release/advanced-use/stylesheets/ */
-+@tailwind base;
-+@tailwind components;
-+@tailwind utilities
-
+"
 package.json
 {
   \\"name\\": \\"test-app\\",
@@ -47,82 +21,77 @@ package.json
     \\"test\\": \\"tests\\"
   },
   \\"scripts\\": {
-    \\"build\\": \\"ember build --environment=production\\",
-    \\"lint\\": \\"concurrently \\\\\\"pnpm:lint:*(!fix)\\\\\\" --names \\\\\\"lint:\\\\\\"\\",
+    \\"build\\": \\"vite build\\",
+    \\"lint\\": \\"concurrently \\\\\\"pnpm:lint:*(!fix)\\\\\\" --names \\\\\\"lint:\\\\\\" --prefixColors auto\\",
     \\"lint:css\\": \\"stylelint \\\\\\"**/*.css\\\\\\"\\",
     \\"lint:css:fix\\": \\"concurrently \\\\\\"pnpm:lint:css -- --fix\\\\\\"\\",
-    \\"lint:fix\\": \\"concurrently \\\\\\"pnpm:lint:*:fix\\\\\\" --names \\\\\\"fix:\\\\\\"\\",
+    \\"lint:fix\\": \\"concurrently \\\\\\"pnpm:lint:*:fix\\\\\\" --names \\\\\\"fix:\\\\\\" --prefixColors auto\\",
     \\"lint:hbs\\": \\"ember-template-lint .\\",
     \\"lint:hbs:fix\\": \\"ember-template-lint . --fix\\",
     \\"lint:js\\": \\"eslint . --cache\\",
     \\"lint:js:fix\\": \\"eslint . --fix\\",
-    \\"lint:types\\": \\"tsc --noEmit\\",
-    \\"start\\": \\"ember serve\\",
-    \\"test\\": \\"concurrently \\\\\\"pnpm:lint\\\\\\" \\\\\\"pnpm:test:*\\\\\\" --names \\\\\\"lint,test:\\\\\\"\\",
-    \\"test:ember\\": \\"ember test\\"
+    \\"lint:types\\": \\"glint\\",
+    \\"start\\": \\"vite\\",
+    \\"test\\": \\"concurrently \\\\\\"pnpm:lint\\\\\\" \\\\\\"pnpm:test:*\\\\\\" --names \\\\\\"lint,test:\\\\\\" --prefixColors auto\\",
+    \\"test:ember\\": \\"vite build --mode test && ember test --path dist\\"
   },
   \\"devDependencies\\": [
     \\"@babel/core\\",
+    \\"@babel/eslint-parser\\",
+    \\"@babel/plugin-transform-runtime\\",
+    \\"@babel/plugin-transform-typescript\\",
+    \\"@babel/runtime\\",
+    \\"@ember-data/adapter\\",
+    \\"@ember-data/graph\\",
+    \\"@ember-data/json-api\\",
+    \\"@ember-data/legacy-compat\\",
+    \\"@ember-data/model\\",
+    \\"@ember-data/request\\",
+    \\"@ember-data/request-utils\\",
+    \\"@ember-data/serializer\\",
+    \\"@ember-data/store\\",
+    \\"@ember-data/tracking\\",
     \\"@ember/optional-features\\",
     \\"@ember/string\\",
     \\"@ember/test-helpers\\",
     \\"@embroider/compat\\",
+    \\"@embroider/config-meta-loader\\",
     \\"@embroider/core\\",
+    \\"@embroider/test-setup\\",
+    \\"@embroider/vite\\",
     \\"@embroider/webpack\\",
+    \\"@eslint/js\\",
     \\"@glimmer/component\\",
     \\"@glimmer/tracking\\",
+    \\"@glint/core\\",
     \\"@glint/environment-ember-loose\\",
+    \\"@glint/environment-ember-template-imports\\",
     \\"@glint/template\\",
+    \\"@rollup/plugin-babel\\",
     \\"@tsconfig/ember\\",
-    \\"@types/ember\\",
-    \\"@types/ember-data\\",
-    \\"@types/ember-data__adapter\\",
-    \\"@types/ember-data__model\\",
-    \\"@types/ember-data__serializer\\",
-    \\"@types/ember-data__store\\",
-    \\"@types/ember__application\\",
-    \\"@types/ember__array\\",
-    \\"@types/ember__component\\",
-    \\"@types/ember__controller\\",
-    \\"@types/ember__debug\\",
-    \\"@types/ember__destroyable\\",
-    \\"@types/ember__engine\\",
-    \\"@types/ember__error\\",
-    \\"@types/ember__helper\\",
-    \\"@types/ember__modifier\\",
-    \\"@types/ember__object\\",
-    \\"@types/ember__owner\\",
-    \\"@types/ember__polyfills\\",
-    \\"@types/ember__routing\\",
-    \\"@types/ember__runloop\\",
-    \\"@types/ember__service\\",
-    \\"@types/ember__string\\",
-    \\"@types/ember__template\\",
-    \\"@types/ember__test\\",
-    \\"@types/ember__utils\\",
+    \\"@types/eslint__js\\",
     \\"@types/qunit\\",
     \\"@types/rsvp\\",
     \\"@typescript-eslint/eslint-plugin\\",
     \\"@typescript-eslint/parser\\",
+    \\"@warp-drive/core-types\\",
     \\"autoprefixer\\",
-    \\"broccoli-asset-rev\\",
+    \\"babel-plugin-ember-template-compilation\\",
     \\"concurrently\\",
+    \\"decorator-transforms\\",
     \\"ember-auto-import\\",
     \\"ember-cli\\",
-    \\"ember-cli-app-version\\",
     \\"ember-cli-babel\\",
-    \\"ember-cli-clean-css\\",
-    \\"ember-cli-dependency-checker\\",
     \\"ember-cli-htmlbars\\",
-    \\"ember-cli-inject-live-reload\\",
     \\"ember-data\\",
-    \\"ember-fetch\\",
     \\"ember-load-initializers\\",
     \\"ember-modifier\\",
     \\"ember-page-title\\",
     \\"ember-qunit\\",
     \\"ember-resolver\\",
+    \\"ember-route-template\\",
     \\"ember-source\\",
+    \\"ember-template-imports\\",
     \\"ember-template-lint\\",
     \\"eslint\\",
     \\"eslint-config-prettier\\",
@@ -130,9 +99,11 @@ package.json
     \\"eslint-plugin-n\\",
     \\"eslint-plugin-prettier\\",
     \\"eslint-plugin-qunit\\",
+    \\"globals\\",
     \\"loader.js\\",
     \\"postcss\\",
     \\"prettier\\",
+    \\"prettier-plugin-ember-template-tag\\",
     \\"qunit\\",
     \\"qunit-dom\\",
     \\"stylelint\\",
@@ -141,43 +112,23 @@ package.json
     \\"tailwindcss\\",
     \\"tracked-built-ins\\",
     \\"typescript\\",
-    \\"webpack\\"
+    \\"typescript-eslint\\",
+    \\"vite\\"
   ],
   \\"engines\\": [
     \\"node\\"
   ],
   \\"ember\\": {
     \\"edition\\": \\"octane\\"
+  },
+  \\"ember-addon\\": {
+    \\"type\\": \\"app\\",
+    \\"version\\": 2
+  },
+  \\"exports\\": {
+    \\"./tests/*\\": \\"./tests/*\\",
+    \\"./*\\": \\"./app/*\\"
   }
 }
-diff --git a/postcss.config.js b/postcss.config.js
-new file mode 100644
-index 0000000..39468d6
---- /dev/null
-+++ b/postcss.config.js
-@@ -0,0 +1,8 @@
-+module.exports = {
-+  plugins: {
-+    tailwindcss: {
-+      config: \\"tailwind.config.js\\"
-+    },
-+    autoprefixer: {},
-+  },
-+}
-diff --git a/tailwind.config.js b/tailwind.config.js
-new file mode 100644
-index 0000000..884a52d
---- /dev/null
-+++ b/tailwind.config.js
-@@ -0,0 +1,9 @@
-+/** @type {import('tailwindcss').Config} */
-+module.exports = {
-+  content: [\\"app/**/*.{js,ts,hbs,gjs,gts,html}\\"],
-+  theme: {
-+    extend: {},
-+  },
-+  plugins: [],
-+}
-+
 "
 `;

--- a/packages/ember/tailwind-vite/__snapshots__/index.test.ts.snap
+++ b/packages/ember/tailwind-vite/__snapshots__/index.test.ts.snap
@@ -1,0 +1,183 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`tailwind-webpack > applying to an ember app > works via CLI 1`] = `
+" app/app.ts               | 2 ++
+ app/styles/app.css       | 3 +++
+ package.json             | 3 +++
+ postcss.config.js (new)  | 8 ++++++++
+ tailwind.config.js (new) | 9 +++++++++
+ 5 files changed, 25 insertions(+)"
+`;
+
+exports[`tailwind-webpack > applying to an ember app > works via CLI 2`] = `
+"diff --git a/app/app.ts b/app/app.ts
+index 1ba9342..daff0cc 100644
+--- a/app/app.ts
++++ b/app/app.ts
+@@ -3,6 +3,8 @@ import Resolver from 'ember-resolver';
+ import loadInitializers from 'ember-load-initializers';
+ import config from 'test-app/config/environment';
+ 
++import './styles/app.css'
++
+ export default class App extends Application {
+   modulePrefix = config.modulePrefix;
+   podModulePrefix = config.podModulePrefix;
+diff --git a/app/styles/app.css b/app/styles/app.css
+index 2763afa..192268f 100644
+--- a/app/styles/app.css
++++ b/app/styles/app.css
+@@ -1 +1,4 @@
+ /* Ember supports plain CSS out of the box. More info: https://cli.emberjs.com/release/advanced-use/stylesheets/ */
++@tailwind base;
++@tailwind components;
++@tailwind utilities
+
+package.json
+{
+  \\"name\\": \\"test-app\\",
+  \\"version\\": \\"0.0.0\\",
+  \\"private\\": true,
+  \\"description\\": \\"Small description for test-app goes here\\",
+  \\"repository\\": \\"\\",
+  \\"license\\": \\"MIT\\",
+  \\"author\\": \\"\\",
+  \\"directories\\": {
+    \\"doc\\": \\"doc\\",
+    \\"test\\": \\"tests\\"
+  },
+  \\"scripts\\": {
+    \\"build\\": \\"ember build --environment=production\\",
+    \\"lint\\": \\"concurrently \\\\\\"pnpm:lint:*(!fix)\\\\\\" --names \\\\\\"lint:\\\\\\"\\",
+    \\"lint:css\\": \\"stylelint \\\\\\"**/*.css\\\\\\"\\",
+    \\"lint:css:fix\\": \\"concurrently \\\\\\"pnpm:lint:css -- --fix\\\\\\"\\",
+    \\"lint:fix\\": \\"concurrently \\\\\\"pnpm:lint:*:fix\\\\\\" --names \\\\\\"fix:\\\\\\"\\",
+    \\"lint:hbs\\": \\"ember-template-lint .\\",
+    \\"lint:hbs:fix\\": \\"ember-template-lint . --fix\\",
+    \\"lint:js\\": \\"eslint . --cache\\",
+    \\"lint:js:fix\\": \\"eslint . --fix\\",
+    \\"lint:types\\": \\"tsc --noEmit\\",
+    \\"start\\": \\"ember serve\\",
+    \\"test\\": \\"concurrently \\\\\\"pnpm:lint\\\\\\" \\\\\\"pnpm:test:*\\\\\\" --names \\\\\\"lint,test:\\\\\\"\\",
+    \\"test:ember\\": \\"ember test\\"
+  },
+  \\"devDependencies\\": [
+    \\"@babel/core\\",
+    \\"@ember/optional-features\\",
+    \\"@ember/string\\",
+    \\"@ember/test-helpers\\",
+    \\"@embroider/compat\\",
+    \\"@embroider/core\\",
+    \\"@embroider/webpack\\",
+    \\"@glimmer/component\\",
+    \\"@glimmer/tracking\\",
+    \\"@glint/environment-ember-loose\\",
+    \\"@glint/template\\",
+    \\"@tsconfig/ember\\",
+    \\"@types/ember\\",
+    \\"@types/ember-data\\",
+    \\"@types/ember-data__adapter\\",
+    \\"@types/ember-data__model\\",
+    \\"@types/ember-data__serializer\\",
+    \\"@types/ember-data__store\\",
+    \\"@types/ember__application\\",
+    \\"@types/ember__array\\",
+    \\"@types/ember__component\\",
+    \\"@types/ember__controller\\",
+    \\"@types/ember__debug\\",
+    \\"@types/ember__destroyable\\",
+    \\"@types/ember__engine\\",
+    \\"@types/ember__error\\",
+    \\"@types/ember__helper\\",
+    \\"@types/ember__modifier\\",
+    \\"@types/ember__object\\",
+    \\"@types/ember__owner\\",
+    \\"@types/ember__polyfills\\",
+    \\"@types/ember__routing\\",
+    \\"@types/ember__runloop\\",
+    \\"@types/ember__service\\",
+    \\"@types/ember__string\\",
+    \\"@types/ember__template\\",
+    \\"@types/ember__test\\",
+    \\"@types/ember__utils\\",
+    \\"@types/qunit\\",
+    \\"@types/rsvp\\",
+    \\"@typescript-eslint/eslint-plugin\\",
+    \\"@typescript-eslint/parser\\",
+    \\"autoprefixer\\",
+    \\"broccoli-asset-rev\\",
+    \\"concurrently\\",
+    \\"ember-auto-import\\",
+    \\"ember-cli\\",
+    \\"ember-cli-app-version\\",
+    \\"ember-cli-babel\\",
+    \\"ember-cli-clean-css\\",
+    \\"ember-cli-dependency-checker\\",
+    \\"ember-cli-htmlbars\\",
+    \\"ember-cli-inject-live-reload\\",
+    \\"ember-data\\",
+    \\"ember-fetch\\",
+    \\"ember-load-initializers\\",
+    \\"ember-modifier\\",
+    \\"ember-page-title\\",
+    \\"ember-qunit\\",
+    \\"ember-resolver\\",
+    \\"ember-source\\",
+    \\"ember-template-lint\\",
+    \\"eslint\\",
+    \\"eslint-config-prettier\\",
+    \\"eslint-plugin-ember\\",
+    \\"eslint-plugin-n\\",
+    \\"eslint-plugin-prettier\\",
+    \\"eslint-plugin-qunit\\",
+    \\"loader.js\\",
+    \\"postcss\\",
+    \\"prettier\\",
+    \\"qunit\\",
+    \\"qunit-dom\\",
+    \\"stylelint\\",
+    \\"stylelint-config-standard\\",
+    \\"stylelint-prettier\\",
+    \\"tailwindcss\\",
+    \\"tracked-built-ins\\",
+    \\"typescript\\",
+    \\"webpack\\"
+  ],
+  \\"engines\\": [
+    \\"node\\"
+  ],
+  \\"ember\\": {
+    \\"edition\\": \\"octane\\"
+  }
+}
+diff --git a/postcss.config.js b/postcss.config.js
+new file mode 100644
+index 0000000..39468d6
+--- /dev/null
++++ b/postcss.config.js
+@@ -0,0 +1,8 @@
++module.exports = {
++  plugins: {
++    tailwindcss: {
++      config: \\"tailwind.config.js\\"
++    },
++    autoprefixer: {},
++  },
++}
+diff --git a/tailwind.config.js b/tailwind.config.js
+new file mode 100644
+index 0000000..884a52d
+--- /dev/null
++++ b/tailwind.config.js
+@@ -0,0 +1,9 @@
++/** @type {import('tailwindcss').Config} */
++module.exports = {
++  content: [\\"app/**/*.{js,ts,hbs,gjs,gts,html}\\"],
++  theme: {
++    extend: {},
++  },
++  plugins: [],
++}
++
+"
+`;

--- a/packages/ember/tailwind-vite/__snapshots__/index.test.ts.snap
+++ b/packages/ember/tailwind-vite/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`tailwind-webpack > applying to an ember app > works via CLI 1`] = `
+exports[`tailwind-vite > applying to an ember app > works via CLI 1`] = `
 " app/app.ts               | 2 ++
  app/styles/app.css       | 3 +++
  package.json             | 3 +++
@@ -9,7 +9,7 @@ exports[`tailwind-webpack > applying to an ember app > works via CLI 1`] = `
  5 files changed, 25 insertions(+)"
 `;
 
-exports[`tailwind-webpack > applying to an ember app > works via CLI 2`] = `
+exports[`tailwind-vite > applying to an ember app > works via CLI 2`] = `
 "diff --git a/app/app.ts b/app/app.ts
 index 1ba9342..daff0cc 100644
 --- a/app/app.ts

--- a/packages/ember/tailwind-vite/__snapshots__/index.test.ts.snap
+++ b/packages/ember/tailwind-vite/__snapshots__/index.test.ts.snap
@@ -1,12 +1,39 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`tailwind-vite > applying to an ember app > works via CLI 1`] = `
-" package.json | 3 +++
- 1 file changed, 3 insertions(+)"
+" app/app.css (new)         | 3 +++
+ app/app.js                | 2 ++
+ package.json              | 3 +++
+ postcss.config.cjs (new)  | 8 ++++++++
+ tailwind.config.cjs (new) | 9 +++++++++
+ 5 files changed, 25 insertions(+)"
 `;
 
 exports[`tailwind-vite > applying to an ember app > works via CLI 2`] = `
-"
+"diff --git a/app/app.css b/app/app.css
+new file mode 100644
+index 0000000..abdf01d
+--- /dev/null
++++ b/app/app.css
+@@ -0,0 +1,3 @@
++@tailwind base
++@tailwind components
++@tailwind utilities
+\\\\ No newline at end of file
+diff --git a/app/app.js b/app/app.js
+index 1ba9342..cbd1516 100644
+--- a/app/app.js
++++ b/app/app.js
+@@ -3,6 +3,8 @@ import Resolver from 'ember-resolver';
+ import loadInitializers from 'ember-load-initializers';
+ import config from 'test-app/config/environment';
+ 
++import './app.css'
++
+ export default class App extends Application {
+   modulePrefix = config.modulePrefix;
+   podModulePrefix = config.podModulePrefix;
+
 package.json
 {
   \\"name\\": \\"test-app\\",
@@ -95,5 +122,34 @@ package.json
     \\"edition\\": \\"octane\\"
   }
 }
+diff --git a/postcss.config.cjs b/postcss.config.cjs
+new file mode 100644
+index 0000000..39468d6
+--- /dev/null
++++ b/postcss.config.cjs
+@@ -0,0 +1,8 @@
++module.exports = {
++  plugins: {
++    tailwindcss: {
++      config: \\"tailwind.config.js\\"
++    },
++    autoprefixer: {},
++  },
++}
+diff --git a/tailwind.config.cjs b/tailwind.config.cjs
+new file mode 100644
+index 0000000..884a52d
+--- /dev/null
++++ b/tailwind.config.cjs
+@@ -0,0 +1,9 @@
++/** @type {import('tailwindcss').Config} */
++module.exports = {
++  content: [\\"app/**/*.{js,ts,hbs,gjs,gts,html}\\"],
++  theme: {
++    extend: {},
++  },
++  plugins: [],
++}
++
 "
 `;

--- a/packages/ember/tailwind-vite/__snapshots__/index.test.ts.snap
+++ b/packages/ember/tailwind-vite/__snapshots__/index.test.ts.snap
@@ -1,8 +1,8 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`tailwind-vite > applying to an ember app > works via CLI 1`] = `
-" package.json | 5 ++++-
- 1 file changed, 4 insertions(+), 1 deletion(-)"
+" package.json | 3 +++
+ 1 file changed, 3 insertions(+)"
 `;
 
 exports[`tailwind-vite > applying to an ember app > works via CLI 2`] = `
@@ -21,78 +21,53 @@ package.json
     \\"test\\": \\"tests\\"
   },
   \\"scripts\\": {
-    \\"build\\": \\"vite build\\",
-    \\"lint\\": \\"concurrently \\\\\\"pnpm:lint:*(!fix)\\\\\\" --names \\\\\\"lint:\\\\\\" --prefixColors auto\\",
+    \\"build\\": \\"ember build --environment=production\\",
+    \\"lint\\": \\"concurrently \\\\\\"npm:lint:*(!fix)\\\\\\" --names \\\\\\"lint:\\\\\\" --prefixColors auto\\",
     \\"lint:css\\": \\"stylelint \\\\\\"**/*.css\\\\\\"\\",
-    \\"lint:css:fix\\": \\"concurrently \\\\\\"pnpm:lint:css -- --fix\\\\\\"\\",
-    \\"lint:fix\\": \\"concurrently \\\\\\"pnpm:lint:*:fix\\\\\\" --names \\\\\\"fix:\\\\\\" --prefixColors auto\\",
+    \\"lint:css:fix\\": \\"concurrently \\\\\\"npm:lint:css -- --fix\\\\\\"\\",
+    \\"lint:fix\\": \\"concurrently \\\\\\"npm:lint:*:fix\\\\\\" --names \\\\\\"fix:\\\\\\" --prefixColors auto\\",
     \\"lint:hbs\\": \\"ember-template-lint .\\",
     \\"lint:hbs:fix\\": \\"ember-template-lint . --fix\\",
     \\"lint:js\\": \\"eslint . --cache\\",
     \\"lint:js:fix\\": \\"eslint . --fix\\",
-    \\"lint:types\\": \\"glint\\",
-    \\"start\\": \\"vite\\",
-    \\"test\\": \\"concurrently \\\\\\"pnpm:lint\\\\\\" \\\\\\"pnpm:test:*\\\\\\" --names \\\\\\"lint,test:\\\\\\" --prefixColors auto\\",
-    \\"test:ember\\": \\"vite build --mode test && ember test --path dist\\"
+    \\"start\\": \\"ember serve\\",
+    \\"test\\": \\"concurrently \\\\\\"npm:lint\\\\\\" \\\\\\"npm:test:*\\\\\\" --names \\\\\\"lint,test:\\\\\\" --prefixColors auto\\",
+    \\"test:ember\\": \\"ember test\\"
   },
   \\"devDependencies\\": [
     \\"@babel/core\\",
     \\"@babel/eslint-parser\\",
-    \\"@babel/plugin-transform-runtime\\",
-    \\"@babel/plugin-transform-typescript\\",
-    \\"@babel/runtime\\",
-    \\"@ember-data/adapter\\",
-    \\"@ember-data/graph\\",
-    \\"@ember-data/json-api\\",
-    \\"@ember-data/legacy-compat\\",
-    \\"@ember-data/model\\",
-    \\"@ember-data/request\\",
-    \\"@ember-data/request-utils\\",
-    \\"@ember-data/serializer\\",
-    \\"@ember-data/store\\",
-    \\"@ember-data/tracking\\",
+    \\"@babel/plugin-proposal-decorators\\",
     \\"@ember/optional-features\\",
     \\"@ember/string\\",
     \\"@ember/test-helpers\\",
-    \\"@embroider/compat\\",
-    \\"@embroider/config-meta-loader\\",
-    \\"@embroider/core\\",
-    \\"@embroider/test-setup\\",
-    \\"@embroider/vite\\",
-    \\"@embroider/webpack\\",
     \\"@eslint/js\\",
     \\"@glimmer/component\\",
     \\"@glimmer/tracking\\",
-    \\"@glint/core\\",
-    \\"@glint/environment-ember-loose\\",
-    \\"@glint/environment-ember-template-imports\\",
-    \\"@glint/template\\",
-    \\"@rollup/plugin-babel\\",
-    \\"@tsconfig/ember\\",
-    \\"@types/eslint__js\\",
-    \\"@types/qunit\\",
-    \\"@types/rsvp\\",
-    \\"@typescript-eslint/eslint-plugin\\",
-    \\"@typescript-eslint/parser\\",
-    \\"@warp-drive/core-types\\",
     \\"autoprefixer\\",
-    \\"babel-plugin-ember-template-compilation\\",
+    \\"broccoli-asset-rev\\",
     \\"concurrently\\",
-    \\"decorator-transforms\\",
     \\"ember-auto-import\\",
     \\"ember-cli\\",
+    \\"ember-cli-app-version\\",
     \\"ember-cli-babel\\",
+    \\"ember-cli-clean-css\\",
+    \\"ember-cli-dependency-checker\\",
     \\"ember-cli-htmlbars\\",
+    \\"ember-cli-inject-live-reload\\",
+    \\"ember-cli-sri\\",
+    \\"ember-cli-terser\\",
     \\"ember-data\\",
+    \\"ember-fetch\\",
     \\"ember-load-initializers\\",
     \\"ember-modifier\\",
     \\"ember-page-title\\",
     \\"ember-qunit\\",
     \\"ember-resolver\\",
-    \\"ember-route-template\\",
     \\"ember-source\\",
     \\"ember-template-imports\\",
     \\"ember-template-lint\\",
+    \\"ember-welcome-page\\",
     \\"eslint\\",
     \\"eslint-config-prettier\\",
     \\"eslint-plugin-ember\\",
@@ -111,23 +86,13 @@ package.json
     \\"stylelint-prettier\\",
     \\"tailwindcss\\",
     \\"tracked-built-ins\\",
-    \\"typescript\\",
-    \\"typescript-eslint\\",
-    \\"vite\\"
+    \\"webpack\\"
   ],
   \\"engines\\": [
     \\"node\\"
   ],
   \\"ember\\": {
     \\"edition\\": \\"octane\\"
-  },
-  \\"ember-addon\\": {
-    \\"type\\": \\"app\\",
-    \\"version\\": 2
-  },
-  \\"exports\\": {
-    \\"./tests/*\\": \\"./tests/*\\",
-    \\"./*\\": \\"./app/*\\"
   }
 }
 "

--- a/packages/ember/tailwind-vite/index.js
+++ b/packages/ember/tailwind-vite/index.js
@@ -19,6 +19,9 @@ export default async function run() {
 
   await execa("npx", ["tailwindcss", "init", "-p"]);
 
+  await fse.rename("tailwind.config.js", "tailwind.config.cjs");
+  await fse.rename("postcss.config.js", "postcss.config.cjs");
+
   await css.transform("app/styles/app.css", {
     Once(root) {
       root.append({ name: "tailwind", params: "base" });
@@ -27,7 +30,7 @@ export default async function run() {
     },
   });
 
-  await js.transform("tailwind.config.js", async ({ root, j }) => {
+  await js.transform("tailwind.config.cjs", async ({ root, j }) => {
     root
       .find(j.AssignmentExpression, {
         left: {
@@ -46,7 +49,7 @@ export default async function run() {
       });
   });
 
-  await js.transform("postcss.config.js", async ({ root, j }) => {
+  await js.transform("postcss.config.cjs", async ({ root, j }) => {
     root
       .find(j.AssignmentExpression, {
         left: {

--- a/packages/ember/tailwind-vite/index.js
+++ b/packages/ember/tailwind-vite/index.js
@@ -1,13 +1,10 @@
 // @ts-check
-import { css, js, packageJson } from "ember-apply";
-// eslint-disable-next-line n/no-unpublished-import
+import { js, packageJson } from "ember-apply";
 import { execa } from "execa";
-// eslint-disable-next-line n/no-unpublished-import
 import fse from "fs-extra";
 import { dirname } from "path";
 import { fileURLToPath } from "url";
 
-// @ts-ignore
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default async function run() {
@@ -17,19 +14,16 @@ export default async function run() {
     autoprefixer: "^10.0.0",
   });
 
-  await execa("npx", ["tailwindcss", "init", "-p"]);
+  await execa("npx", ["tailwindcss@^3.4.17", "init", "-p"], { preferLocal: true, shell: true });
 
   await fse.rename("tailwind.config.js", "tailwind.config.cjs");
   await fse.rename("postcss.config.js", "postcss.config.cjs");
 
-  await fse.ensureFile("app/app.css");
-  await css.transform("app/app.css", {
-    Once(root) {
-      root.append({ name: "tailwind", params: "base" });
-      root.append({ name: "tailwind", params: "components" });
-      root.append({ name: "tailwind", params: "utilities" });
-    },
-  });
+  await fse.writeFile("app/app.css", [
+    '@tailwind base',
+    '@tailwind components',
+    '@tailwind utilities'
+  ].join('\n'));
 
   await js.transform("tailwind.config.cjs", async ({ root, j }) => {
     root

--- a/packages/ember/tailwind-vite/index.js
+++ b/packages/ember/tailwind-vite/index.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { files, js, css, packageJson } from "ember-apply";
+import { css, js, packageJson } from "ember-apply";
 // eslint-disable-next-line n/no-unpublished-import
 import { execa } from "execa";
 // eslint-disable-next-line n/no-unpublished-import

--- a/packages/ember/tailwind-vite/index.js
+++ b/packages/ember/tailwind-vite/index.js
@@ -22,7 +22,8 @@ export default async function run() {
   await fse.rename("tailwind.config.js", "tailwind.config.cjs");
   await fse.rename("postcss.config.js", "postcss.config.cjs");
 
-  await css.transform("app/styles/app.css", {
+  await fse.ensureFile("app/app.css");
+  await css.transform("app/app.css", {
     Once(root) {
       root.append({ name: "tailwind", params: "base" });
       root.append({ name: "tailwind", params: "components" });
@@ -85,7 +86,7 @@ export default async function run() {
       .find(j.ImportDefaultSpecifier)
       .filter((path) => path.node.local?.name === "config")
       .forEach((path) => {
-        path.parent.insertAfter(`import './styles/app.css'`);
+        path.parent.insertAfter(`import './app.css'`);
       });
   });
 

--- a/packages/ember/tailwind-vite/index.js
+++ b/packages/ember/tailwind-vite/index.js
@@ -1,0 +1,92 @@
+// @ts-check
+import { files, js, css, packageJson } from "ember-apply";
+// eslint-disable-next-line n/no-unpublished-import
+import { execa } from "execa";
+// eslint-disable-next-line n/no-unpublished-import
+import fse from "fs-extra";
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+
+// @ts-ignore
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default async function run() {
+  await packageJson.addDevDependencies({
+    tailwindcss: "^3.0.0",
+    postcss: "^8.0.0",
+    autoprefixer: "^10.0.0",
+  });
+
+  await execa("npx", ["tailwindcss", "init", "-p"]);
+
+  await css.transform("app/styles/app.css", {
+    Once(root) {
+      root.append({ name: "tailwind", params: "base" });
+      root.append({ name: "tailwind", params: "components" });
+      root.append({ name: "tailwind", params: "utilities" });
+    },
+  });
+
+  await js.transform("tailwind.config.js", async ({ root, j }) => {
+    root
+      .find(j.AssignmentExpression, {
+        left: {
+          object: { name: "module" },
+          property: { name: "exports" },
+        },
+      })
+      .forEach((path) => {
+        const contentProperty = path.value.right.properties.find(
+          (prop) => prop.key.name === "content"
+        );
+
+        contentProperty.value.elements.push(
+          j.literal("app/**/*.{js,ts,hbs,gjs,gts,html}")
+        );
+      });
+  });
+
+  await js.transform("postcss.config.js", async ({ root, j }) => {
+    root
+      .find(j.AssignmentExpression, {
+        left: {
+          object: { name: "module" },
+          property: { name: "exports" },
+        },
+      })
+      .forEach((path) => {
+        const pluginsProperty = path.value.right.properties.find(
+          (prop) => prop.key.name === "plugins"
+        );
+
+        const tailwindcssProperty = pluginsProperty.value.properties.find(
+          (prop) => prop.key.name === "tailwindcss"
+        );
+
+        tailwindcssProperty.value.properties.push(
+          j.property(
+            "init",
+            j.identifier("config"),
+            j.literal("tailwind.config.js")
+          )
+        );
+      });
+  });
+
+  const appFile = (await fse.pathExists("app/app.ts"))
+    ? "app/app.ts"
+    : "app/app.js";
+
+  await js.transform(appFile, async ({ root, j }) => {
+    root
+      .find(j.ImportDefaultSpecifier)
+      .filter((path) => path.node.local?.name === "config")
+      .forEach((path) => {
+        path.parent.insertAfter(`import './styles/app.css'`);
+      });
+  });
+
+  await execa("git", ["add", ".", "-N"]);
+}
+
+run.path = __dirname;

--- a/packages/ember/tailwind-vite/index.test.ts
+++ b/packages/ember/tailwind-vite/index.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import { default as tailwindVite } from "./index.js";
 
-describe("tailwind-webpack", () => {
+describe("tailwind-vite", () => {
   it("default export exists", () => {
     expect(typeof tailwindVite).toEqual("function");
   });

--- a/packages/ember/tailwind-vite/index.test.ts
+++ b/packages/ember/tailwind-vite/index.test.ts
@@ -1,0 +1,23 @@
+import { apply, diff, diffSummary, newEmberApp } from "ember-apply/test-utils";
+import { describe, expect, it } from "vitest";
+
+import { default as tailwindVite } from "./index.js";
+
+describe("tailwind-webpack", () => {
+  it("default export exists", () => {
+    expect(typeof tailwindVite).toEqual("function");
+  });
+
+  describe("applying to an ember app", () => {
+    it("works via CLI", async () => {
+      let appLocation = await newEmberApp();
+
+      await apply(appLocation, tailwindVite.path);
+
+      expect(await diffSummary(appLocation)).toMatchSnapshot();
+      expect(
+        await diff(appLocation, { ignoreVersions: true })
+      ).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/ember/tailwind-vite/package.json
+++ b/packages/ember/tailwind-vite/package.json
@@ -30,6 +30,8 @@
     "files/**/*"
   ],
   "dependencies": {
+    "execa": "^8.0.1",
+    "fs-extra": "^11.2.0",
     "ember-apply": "workspace:^"
   },
   "devDependencies": {
@@ -44,8 +46,6 @@
     "eslint-plugin-import": "^2.29.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^5.0.1",
-    "execa": "^8.0.1",
-    "fs-extra": "^11.1.1",
     "prettier": "^3.1.0",
     "typescript": "5.3.3",
     "vite": "^5.0.0",

--- a/packages/ember/tailwind-vite/package.json
+++ b/packages/ember/tailwind-vite/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@ember-apply/tailwind-vite",
+  "version": "1.0.0",
+  "description": "ember-apply plugin for tailwind-vite",
+  "main": "index.js",
+  "scripts": {
+    "lint:types": "tsc",
+    "build": "tsc --build",
+    "lint": "pnpm lint:js",
+    "lint:js": "eslint .",
+    "lint:fix": "pnpm lint:js --fix",
+    "test": "vitest --coverage --no-watch",
+    "test:watch": "vitest --watch"
+  },
+  "keywords": [
+    "ember",
+    "tailwind",
+    "css",
+    "ember-apply",
+    "blueprint"
+  ],
+  "author": "Michal Bryxí",
+  "type": "module",
+  "license": "MIT",
+  "exports": {
+    "import": "./index.js"
+  },
+  "files": [
+    "index.js",
+    "files/**/*"
+  ],
+  "dependencies": {
+    "ember-apply": "workspace:^"
+  },
+  "devDependencies": {
+    "@babel/eslint-parser": "^7.23.3",
+    "@nullvoxpopuli/eslint-configs": "^3.2.2",
+    "@typescript-eslint/eslint-plugin": "^6.11.0",
+    "@typescript-eslint/parser": "^6.11.0",
+    "@vitest/coverage-v8": "^0.34.6",
+    "c8": "^8.0.1",
+    "eslint": "^8.54.0",
+    "eslint-plugin-decorator-position": "^5.0.2",
+    "eslint-plugin-import": "^2.29.0",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-prettier": "^5.0.1",
+    "execa": "^8.0.1",
+    "fs-extra": "^11.1.1",
+    "prettier": "^3.1.0",
+    "typescript": "5.3.3",
+    "vite": "^5.0.0",
+    "vitest": "^0.34.6"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "volta": {
+    "node": "20.15.0"
+  }
+}

--- a/packages/ember/tailwind-vite/tsconfig.json
+++ b/packages/ember/tailwind-vite/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.compiler-options.json",
+  "include": ["src/**/*"],
+  "references": [
+    { "path": "../../../ember-apply" }
+  ],
+}

--- a/packages/ember/tailwind-vite/vitest.config.ts
+++ b/packages/ember/tailwind-vite/vitest.config.ts
@@ -1,0 +1,9 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  test: {
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,7 +137,7 @@ importers:
         version: 5.0.2(@babel/eslint-parser@7.24.7(@babel/core@7.24.7)(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-import:
         specifier: ^2.29.0
-        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-node:
         specifier: ^11.1.0
         version: 11.1.0(eslint@8.57.0)
@@ -210,7 +210,7 @@ importers:
         version: 5.0.2(@babel/eslint-parser@7.24.7(@babel/core@7.24.7)(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-import:
         specifier: ^2.29.0
-        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-node:
         specifier: ^11.1.0
         version: 11.1.0(eslint@8.57.0)
@@ -265,7 +265,7 @@ importers:
         version: 5.0.2(@babel/eslint-parser@7.24.7(@babel/core@7.24.7)(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-import:
         specifier: ^2.29.0
-        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-node:
         specifier: ^11.1.0
         version: 11.1.0(eslint@8.57.0)
@@ -281,6 +281,64 @@ importers:
       vite:
         specifier: ^5.0.0
         version: 5.4.12(@types/node@20.14.10)
+      vitest:
+        specifier: ^0.34.6
+        version: 0.34.6(@vitest/ui@0.34.7)
+
+  packages/ember/tailwind-vite:
+    dependencies:
+      ember-apply:
+        specifier: workspace:^
+        version: link:../../../ember-apply
+    devDependencies:
+      '@babel/eslint-parser':
+        specifier: ^7.23.3
+        version: 7.24.7(@babel/core@7.24.7)(eslint@8.57.0)
+      '@nullvoxpopuli/eslint-configs':
+        specifier: ^3.2.2
+        version: 3.2.2(@babel/core@7.24.7)(@babel/eslint-parser@7.24.7(@babel/core@7.24.7)(eslint@8.57.0))(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3))(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(prettier@3.3.2)(typescript@5.3.3)
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^6.11.0
+        version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3)
+      '@typescript-eslint/parser':
+        specifier: ^6.11.0
+        version: 6.21.0(eslint@8.57.0)(typescript@5.3.3)
+      '@vitest/coverage-v8':
+        specifier: ^0.34.6
+        version: 0.34.6(vitest@0.34.6(@vitest/ui@0.34.7))
+      c8:
+        specifier: ^8.0.1
+        version: 8.0.1
+      eslint:
+        specifier: ^8.54.0
+        version: 8.57.0
+      eslint-plugin-decorator-position:
+        specifier: ^5.0.2
+        version: 5.0.2(@babel/eslint-parser@7.24.7(@babel/core@7.24.7)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import:
+        specifier: ^2.29.0
+        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-node:
+        specifier: ^11.1.0
+        version: 11.1.0(eslint@8.57.0)
+      eslint-plugin-prettier:
+        specifier: ^5.0.1
+        version: 5.1.3(eslint@8.57.0)(prettier@3.3.2)
+      execa:
+        specifier: ^8.0.1
+        version: 8.0.1
+      fs-extra:
+        specifier: ^11.1.1
+        version: 11.2.0
+      prettier:
+        specifier: ^3.1.0
+        version: 3.3.2
+      typescript:
+        specifier: 5.3.3
+        version: 5.3.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.3.3(@types/node@20.14.10)
       vitest:
         specifier: ^0.34.6
         version: 0.34.6(@vitest/ui@0.34.7)
@@ -317,7 +375,7 @@ importers:
         version: 5.0.2(@babel/eslint-parser@7.24.7(@babel/core@7.24.7)(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-import:
         specifier: ^2.29.0
-        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-node:
         specifier: ^11.1.0
         version: 11.1.0(eslint@8.57.0)
@@ -408,7 +466,7 @@ importers:
         version: 5.0.2(@babel/eslint-parser@7.24.7(@babel/core@7.24.7)(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-import:
         specifier: ^2.29.0
-        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-node:
         specifier: ^11.1.0
         version: 11.1.0(eslint@8.57.0)
@@ -472,7 +530,7 @@ importers:
         version: 5.0.2(@babel/eslint-parser@7.24.7(@babel/core@7.24.7)(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-import:
         specifier: ^2.29.0
-        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-node:
         specifier: ^11.1.0
         version: 11.1.0(eslint@8.57.0)
@@ -542,7 +600,7 @@ importers:
         version: 5.0.2(@babel/eslint-parser@7.24.7(@babel/core@7.24.7)(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-import:
         specifier: ^2.29.0
-        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-node:
         specifier: ^11.1.0
         version: 11.1.0(eslint@8.57.0)
@@ -6575,9 +6633,9 @@ snapshots:
     dependencies:
       cosmiconfig: 8.3.6(typescript@5.3.3)
       eslint: 8.57.0
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-decorator-position: 5.0.2(@babel/eslint-parser@7.24.7(@babel/core@7.24.7)(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-json: 3.1.0
       eslint-plugin-n: 16.6.2(eslint@8.57.0)
       eslint-plugin-prettier: 4.2.1(eslint@8.57.0)(prettier@3.3.2)
@@ -8192,13 +8250,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 4.3.5
       enhanced-resolve: 5.17.0
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.14.0
@@ -8209,14 +8267,14 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -8246,7 +8304,7 @@ snapshots:
       eslint-utils: 2.1.0
       regexpp: 3.2.0
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -8256,7 +8314,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.14.0
       is-glob: 4.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,6 +290,12 @@ importers:
       ember-apply:
         specifier: workspace:^
         version: link:../../../ember-apply
+      execa:
+        specifier: ^8.0.1
+        version: 8.0.1
+      fs-extra:
+        specifier: ^11.2.0
+        version: 11.2.0
     devDependencies:
       '@babel/eslint-parser':
         specifier: ^7.23.3
@@ -324,12 +330,6 @@ importers:
       eslint-plugin-prettier:
         specifier: ^5.0.1
         version: 5.1.3(eslint@8.57.0)(prettier@3.3.2)
-      execa:
-        specifier: ^8.0.1
-        version: 8.0.1
-      fs-extra:
-        specifier: ^11.1.1
-        version: 11.2.0
       prettier:
         specifier: ^3.1.0
         version: 3.3.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,7 +137,7 @@ importers:
         version: 5.0.2(@babel/eslint-parser@7.24.7(@babel/core@7.24.7)(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-import:
         specifier: ^2.29.0
-        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-node:
         specifier: ^11.1.0
         version: 11.1.0(eslint@8.57.0)
@@ -210,7 +210,7 @@ importers:
         version: 5.0.2(@babel/eslint-parser@7.24.7(@babel/core@7.24.7)(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-import:
         specifier: ^2.29.0
-        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-node:
         specifier: ^11.1.0
         version: 11.1.0(eslint@8.57.0)
@@ -265,7 +265,7 @@ importers:
         version: 5.0.2(@babel/eslint-parser@7.24.7(@babel/core@7.24.7)(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-import:
         specifier: ^2.29.0
-        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-node:
         specifier: ^11.1.0
         version: 11.1.0(eslint@8.57.0)
@@ -317,7 +317,7 @@ importers:
         version: 5.0.2(@babel/eslint-parser@7.24.7(@babel/core@7.24.7)(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-import:
         specifier: ^2.29.0
-        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-node:
         specifier: ^11.1.0
         version: 11.1.0(eslint@8.57.0)
@@ -338,7 +338,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.0
-        version: 5.3.3(@types/node@20.14.10)
+        version: 5.4.12(@types/node@20.14.10)
       vitest:
         specifier: ^0.34.6
         version: 0.34.6(@vitest/ui@0.34.7)
@@ -375,7 +375,7 @@ importers:
         version: 5.0.2(@babel/eslint-parser@7.24.7(@babel/core@7.24.7)(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-import:
         specifier: ^2.29.0
-        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-node:
         specifier: ^11.1.0
         version: 11.1.0(eslint@8.57.0)
@@ -466,7 +466,7 @@ importers:
         version: 5.0.2(@babel/eslint-parser@7.24.7(@babel/core@7.24.7)(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-import:
         specifier: ^2.29.0
-        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-node:
         specifier: ^11.1.0
         version: 11.1.0(eslint@8.57.0)
@@ -530,7 +530,7 @@ importers:
         version: 5.0.2(@babel/eslint-parser@7.24.7(@babel/core@7.24.7)(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-import:
         specifier: ^2.29.0
-        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-node:
         specifier: ^11.1.0
         version: 11.1.0(eslint@8.57.0)
@@ -600,7 +600,7 @@ importers:
         version: 5.0.2(@babel/eslint-parser@7.24.7(@babel/core@7.24.7)(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-import:
         specifier: ^2.29.0
-        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+        version: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-node:
         specifier: ^11.1.0
         version: 11.1.0(eslint@8.57.0)
@@ -5685,7 +5685,7 @@ snapshots:
       '@babel/helper-validator-identifier': 7.24.7
       chalk: 2.4.2
       js-tokens: 4.0.0
-      picocolors: 1.0.1
+      picocolors: 1.1.1
 
   '@babel/parser@7.24.7':
     dependencies:
@@ -6633,9 +6633,9 @@ snapshots:
     dependencies:
       cosmiconfig: 8.3.6(typescript@5.3.3)
       eslint: 8.57.0
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
       eslint-plugin-decorator-position: 5.0.2(@babel/eslint-parser@7.24.7(@babel/core@7.24.7)(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-json: 3.1.0
       eslint-plugin-n: 16.6.2(eslint@8.57.0)
       eslint-plugin-prettier: 4.2.1(eslint@8.57.0)(prettier@3.3.2)
@@ -8250,13 +8250,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0):
     dependencies:
       debug: 4.3.5
       enhanced-resolve: 5.17.0
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.14.0
@@ -8267,14 +8267,14 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -8304,7 +8304,7 @@ snapshots:
       eslint-utils: 2.1.0
       regexpp: 3.2.0
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -8314,7 +8314,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.14.0
       is-glob: 4.0.3
@@ -10986,7 +10986,7 @@ snapshots:
     dependencies:
       browserslist: 4.23.1
       escalade: 3.1.2
-      picocolors: 1.0.1
+      picocolors: 1.1.1
 
   uri-js@4.4.1:
     dependencies:


### PR DESCRIPTION
- Makes [official tailwind + vite](https://tailwindcss.com/docs/guides/vite) config
- Assumes use of [embroider-build/app-blueprint](https://github.com/embroider-build/app-blueprint) for app bootstrap
- Fixes #578
