### PR TITLE
Fix for vite tailwind4

### DIFF
--- a/packages/ember/tailwind4-vite/index.js
+++ b/packages/ember/tailwind4-vite/index.js
@@ -87,7 +87,7 @@ async function updateHtmlLink(htmlFile) {
         tag: "link",
         attrs: {
           rel: "stylesheet",
-          href: /^\/assets\/.*\.css$/,
+          href: /^\/assets\/.*\.css|\/@embroider\/virtual\/app\.css$/,
         },
       },
       (node) => {


### PR DESCRIPTION
Look for /@embroider/virtual/app.css as well

<sup>I still 100% believe we should be linking to on-disk css by default :(</sup>